### PR TITLE
A few changes for use by BW

### DIFF
--- a/bw-prep.js
+++ b/bw-prep.js
@@ -49,6 +49,7 @@ const YAML = require('yaml');
   alterIndex(response.hasDS);
   // change ci.yml
   removeCC();
+  removeThemeFromCraco();
   // remove storybook stories
   fs.rmdirSync('./src/stories', { recursive: true });
   fs.rmdirSync('./.storybook', { recursive: true });
@@ -56,6 +57,11 @@ const YAML = require('yaml');
   fs.rmdirSync('./src/styles', { recursive: true });
   // remove scaffold .git 😈
   fs.rmdirSync('./.git', { recursive: true });
+  // copy the .env.sample file to .env
+  fs.copyFile('./.env.sample', './.env', (err) => {
+    if (err) throw err;
+    console.log('.env.sample was copied to .env');
+  });
   // remove this file 😱
   fs.unlinkSync('./bw-prep.js');
 })();
@@ -111,6 +117,16 @@ function alterIndex(hasDS) {
   } catch (e) {
     console.error(e);
   }
+}
+
+function removeThemeFromCraco() {
+  const fileName = './craco.config.js';
+  const file = fs.readFileSync(fileName, 'utf8');
+  var lines = file.split('\n');
+  lines.splice(10, 1);
+  lines.splice(0, 1);
+  const result = lines.map(line => line).join('\n');
+  fs.writeFileSync(fileName, result, 'utf8');
 }
 
 function replaceHomePage(lines) {

--- a/bw-prep.js
+++ b/bw-prep.js
@@ -1,0 +1,133 @@
+const prompts = require('prompts');
+const fs = require('fs');
+const { exec } = require('child_process');
+const kleur = require('kleur');
+const YAML = require('yaml');
+
+/***
+ * In order to better serve build week teams we want to remove some items that
+ * can cause distraction from the unit objectives.
+ *
+ * Packages removed
+ * - ant design
+ * - storybook
+ * - plotly (if not a team with DS)
+ *
+ * Alter the index.js file
+ * Remove code climate from ci.yml
+ */
+(async () => {
+  console.log(kleur.bold().cyan('Preparing Labs Scaffold for BW projects'));
+
+  const response = await prompts({
+    type: 'confirm',
+    name: 'hasDS',
+    message: 'Does your team have data science members?',
+    initial: false,
+  });
+
+  // console.log(response);
+  var packages = [
+    '@storybook/react',
+    '@storybook/addon-actions',
+    '@storybook/addon-knobs',
+    '@storybook/addon-notes',
+    '@storybook/addons',
+    '@storybook/storybook-deployer',
+    'antd',
+    'prompts',
+    'kleur',
+    'yaml',
+  ];
+  if (!response.hasDS) {
+    // remove dataviz example component
+    fs.rmdirSync('./src/components/pages/ExampleDataViz', { recursive: true });
+    // add plotly packages to be removed
+    packages.push('plotly.js', 'react-plotly.js');
+  }
+  uninstall(packages);
+  // remove lines from app index.js
+  alterIndex(response.hasDS);
+  // change ci.yml
+  removeCC();
+  // remove storybook stories
+  fs.rmdirSync('./src/stories', { recursive: true });
+  fs.rmdirSync('./.storybook', { recursive: true });
+  // remove ant files
+  fs.rmdirSync('./src/styles', { recursive: true });
+  // remove scaffold .git 😈
+  fs.rmdirSync('./.git', { recursive: true });
+  // remove this file 😱
+  fs.unlinkSync('./bw-prep.js');
+})();
+
+function removeCC() {
+  const ciFile = './.github/workflows/ci.yml';
+  const file = fs.readFileSync(ciFile, 'utf8');
+  const ci = YAML.parse(file);
+  //remove the code climate step
+  ci.jobs.coverage.steps.pop();
+  //add a build step
+  ci.jobs.coverage.steps.push({ run: 'npm run build' });
+  fs.writeFileSync(ciFile, YAML.stringify(ci), 'utf8');
+}
+
+function uninstall(packages) {
+  const packageNames = packages.join(' ');
+  console.log(kleur.bold(`uninstalling packages: ${packageNames}`));
+  exec(`npm uninstall ${packageNames}`, (error, stdout, stderr) => {
+    console.log(stderr);
+    if (error !== null) {
+      console.log(
+        kleur
+          .bold()
+          .yellow()
+          .bgRed(`exec error: ${error}`)
+      );
+    }
+    // why not run git init for them?
+    console.log(
+      kleur.bold().green('Uninstall complete'),
+      `\n\nThe scaffold is now ready for your Build Week project. You may now run ${kleur
+        .bold()
+        .underline('git init')} \n\n🎉🎉🎉🎉 🚀`
+    );
+  });
+}
+
+function alterIndex(hasDS) {
+  var indexFile = './src/index.js';
+  try {
+    var file = fs.readFileSync(indexFile, 'utf8');
+    var lines = file.split('\n');
+    replaceHomePage(lines);
+    if (!hasDS) lines = removeLines(lines, 'ExampleDataViz');
+    lines = removeLines(lines, 'antd');
+    lines = removeLines(lines, 'ProfileListPage');
+    lines = removeLines(lines, 'HomePage');
+    lines = removeLines(lines, 'LoadingComponent');
+
+    var result = lines.join('\n');
+    fs.writeFileSync(indexFile, result, 'utf8');
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+function replaceHomePage(lines) {
+  // super brittle stuff here
+  lines[49] = lines[49].replace(/SecureRoute/g, 'Route');
+  lines[54] = lines[54].replace(/SecureRoute/g, 'Route');
+  lines[52] = lines[52].replace(
+    /HomePage LoadingComponent={LoadingComponent}/g,
+    'LandingPage'
+  );
+}
+
+function removeLines(fileLines, matchStr) {
+  let indexes = [];
+  for (let i = fileLines.length - 1; i > -1; i--)
+    if (fileLines[i].match(matchStr)) indexes.push(i);
+  for (let l = 0; l < indexes.length; l++) fileLines.splice(indexes[l], 1);
+  return fileLines.map(s => s);
+}

--- a/bw-prep.js
+++ b/bw-prep.js
@@ -26,7 +26,6 @@ const YAML = require('yaml');
     initial: false,
   });
 
-  // console.log(response);
   var packages = [
     '@storybook/react',
     '@storybook/addon-actions',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14186,9 +14186,10 @@
       }
     },
     "kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.1.tgz",
+      "integrity": "sha512-BsNhM6T/yTWFG580CRnYhT3LfUuPK7Hwrm+W2H0G8lK/nogalP5Nsrh/cHjxVVkzl0sFm7z8b8rNcZCfKxeoxA==",
+      "dev": true
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
@@ -18836,6 +18837,13 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
+      },
+      "dependencies": {
+        "kleur": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+          "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+        }
       }
     },
     "prop-types": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "labs-spa-starter",
   "version": "0.1.0",
   "private": false,
-  "license" : "MIT",
+  "license": "MIT",
   "repository": "github:Lambda-School-Labs/labs-spa-starter",
-  
   "dependencies": {
     "@craco/craco": "^5.6.4",
     "@okta/okta-react": "^3.0.2",
@@ -82,7 +81,10 @@
     "jest-canvas-mock": "^2.2.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-prop-type-error": "^1.1.0",
+    "kleur": "^4.1.1",
     "lint-staged": "^10.2.11",
-    "prettier-eslint-cli": "^5.0.0"
+    "prettier-eslint-cli": "^5.0.0",
+    "prompts": "^2.3.2",
+    "yaml": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "extends": "react-app"
   },
   "lint-staged": {
-    "**/*.js": [
+    "src/**/*.{js,jsx}": [
       "eslint --fix",
       "prettier-eslint --write"
     ]

--- a/src/__tests__/RenderHomePage.test.js
+++ b/src/__tests__/RenderHomePage.test.js
@@ -14,7 +14,7 @@ describe('<RenderHomePage /> test suite', () => {
         <RenderHomePage userInfo={{ name: 'Sara' }} authService={authService} />
       </Router>
     );
-    const button = getByText(/Logout/i);
+    const button = getByText(/logout/i);
     userEvent.click(button);
     expect(authService.logout).toHaveBeenCalledTimes(1);
     expect(getByText(/hi sara welcome to labs basic spa/i).innerHTML).toBe(

--- a/src/__tests__/RenderHomePage.test.js
+++ b/src/__tests__/RenderHomePage.test.js
@@ -14,7 +14,7 @@ describe('<RenderHomePage /> test suite', () => {
         <RenderHomePage userInfo={{ name: 'Sara' }} authService={authService} />
       </Router>
     );
-    const button = getByText(/logout/i);
+    const button = getByText(/Logout/i);
     userEvent.click(button);
     expect(authService.logout).toHaveBeenCalledTimes(1);
     expect(getByText(/hi sara welcome to labs basic spa/i).innerHTML).toBe(

--- a/src/components/pages/Home/RenderHomePage.js
+++ b/src/components/pages/Home/RenderHomePage.js
@@ -22,7 +22,10 @@ function RenderHomePage(props) {
           <Link to="/datavis">Data Visualizations Example</Link>
         </p>
         <p>
-          <Button onClick={() => authService.logout()} buttonText="Logout" />
+          <Button
+            handleClick={() => authService.logout()}
+            buttonText="Logout"
+          />
         </p>
       </div>
     </div>

--- a/src/components/pages/Home/RenderHomePage.js
+++ b/src/components/pages/Home/RenderHomePage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Button } from 'antd';
+import { Button } from '../../common';
 
 function RenderHomePage(props) {
   const { userInfo, authService } = props;
@@ -22,9 +22,7 @@ function RenderHomePage(props) {
           <Link to="/datavis">Data Visualizations Example</Link>
         </p>
         <p>
-          <Button type="primary" onClick={() => authService.logout()}>
-            Logout
-          </Button>
+          <Button onClick={() => authService.logout()} buttonText="Logout" />
         </p>
       </div>
     </div>

--- a/src/components/pages/Landing/LandingContainer.js
+++ b/src/components/pages/Landing/LandingContainer.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import RenderLandingPage from './RenderLandingPage';
+
+function LandingContainer({ LoadingComponent }) {
+  return (
+    <>
+      <RenderLandingPage />
+    </>
+  );
+}
+
+export default LandingContainer;

--- a/src/components/pages/Landing/RenderLandingPage.js
+++ b/src/components/pages/Landing/RenderLandingPage.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function RenderLandingPage(props) {
+  return (
+    <div>
+      <h1>Welcome to Labs Basic SPA</h1>
+      <div>
+        <p>
+          This is an example of how we'd like for you to approach page/routable
+          components.
+        </p>
+        <p>
+          <Link to="/example-list">Example List of Items</Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+export default RenderLandingPage;

--- a/src/components/pages/Landing/index.js
+++ b/src/components/pages/Landing/index.js
@@ -1,0 +1,1 @@
+export { default as LandingPage } from './LandingContainer';

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import { ExampleListPage } from './components/pages/ExampleList';
 import { ProfileListPage } from './components/pages/ProfileList';
 import { LoginPage } from './components/pages/Login';
 import { HomePage } from './components/pages/Home';
+import { LandingPage } from './components/pages/Landing';
 import { ExampleDataViz } from './components/pages/ExampleDataViz';
 import { config } from './utils/oktaConfig';
 import { LoadingComponent } from './components/common';
@@ -44,6 +45,7 @@ function App() {
       <Switch>
         <Route path="/login" component={LoginPage} />
         <Route path="/implicit/callback" component={LoginCallback} />
+        <Route path="/landing" component={LandingPage} />
         {/* any of the routes you need secured should be registered as SecureRoutes */}
         <SecureRoute
           path="/"


### PR DESCRIPTION
After a discussion with Edd this morning (20 Aug) there were a few concerns he had. Given there will be students from Units 2-4 working in the FE app there were a few areas that could distract them all from their objectives. Rather than creating a custom branch or separate repo I've created a script to make the alterations before they `git init` and push to their new repo.

Running the `node bw-prep.js` script will produce the following changes:

- remove the `.git` folder
- Remove code climate from ci.yml
- uninstall modules
  - ant design
  - storybook
  - prompts, kleur, yaml
  - plotly (if not a team with DS)
- Alter the index.js file
  - make / route to LandingPage
  - remove ProfilesListPage
  - remove HomePage
  - remove LoadingComponent
  - remove antd

```
modified:   .github/workflows/ci.yml
modified:   package-lock.json
modified:   package.json
modified:   src/index.js
deleted:    .storybook/main.js
deleted:    bw-prep.js
deleted:    src/components/pages/ExampleDataViz/ExampleDataVizContainer.js
deleted:    src/components/pages/ExampleDataViz/README.md
deleted:    src/components/pages/ExampleDataViz/RenderDataViz.js
deleted:    src/components/pages/ExampleDataViz/index.js
deleted:    src/components/pages/ExampleDataViz/statedata.js
deleted:    src/stories/Form.stories.js
deleted:    src/stories/FormButton.stories.js
deleted:    src/stories/FormInput.stories.js
deleted:    src/stories/List.stories.js
deleted:    src/stories/LoadingComponent.stories.js
deleted:    src/stories/README.md
deleted:    src/stories/story_descriptions/Form.md
deleted:    src/stories/story_descriptions/FormButton.md
deleted:    src/stories/story_descriptions/FormInput.md
deleted:    src/stories/story_descriptions/List.md
deleted:    src/stories/story_descriptions/LoadingComponent.md
deleted:    src/styles/theme-overrides.js
```

![image](https://user-images.githubusercontent.com/4095/90932989-99af9800-e3bc-11ea-8757-fbdff7380f9f.png)
